### PR TITLE
Add HEAD support

### DIFF
--- a/src/main/java/com/despegar/sparkjava/test/SparkServer.java
+++ b/src/main/java/com/despegar/sparkjava/test/SparkServer.java
@@ -15,6 +15,7 @@ import com.despegar.http.client.OptionsMethod;
 import com.despegar.http.client.PatchMethod;
 import com.despegar.http.client.PostMethod;
 import com.despegar.http.client.PutMethod;
+import com.despegar.http.client.WithoutBodyMethod;
 
 import spark.Service;
 import spark.Spark;
@@ -98,6 +99,16 @@ public class SparkServer<T extends SparkApplication> extends ExternalResource {
 	
 	public OptionsMethod options(String path, boolean followRedirect) {
 		return new OptionsMethod(this.protocolHostPort + path, followRedirect);
+	}
+	
+	public HeadMethod head(String path, boolean followRedirect) {
+		return new HeadMethod(this.protocolHostPort + path, followRedirect);
+	}
+	
+	public static class HeadMethod extends WithoutBodyMethod {
+		public HeadMethod(String url, boolean followRedirects) {
+			super(url, "HEAD", followRedirects);
+		}
 	}
 	
 	public HttpResponse execute(HttpMethod httpMethod) throws HttpClientException {

--- a/src/test/java/com/despegar/sparkjava/test/TestController.java
+++ b/src/test/java/com/despegar/sparkjava/test/TestController.java
@@ -1,6 +1,7 @@
 package com.despegar.sparkjava.test;
 
 import static spark.Spark.get;
+import static spark.Spark.head;
 
 import spark.Request;
 import spark.Response;
@@ -14,10 +15,16 @@ public class TestController {
 
 	public TestController() {
 		get("/test", (request, response) ->  this.testMethod(request, response));
+		head("/test", (request, response) ->  this.testHeadMethod(request, response));
 	}
 	
 	public String testMethod(Request request, Response response) {
 		return "This works!";
 	}
 		
+	public String testHeadMethod(Request request, Response response) {
+		response.header("foo", "bar");
+		return "";
+	}
+	
 }

--- a/src/test/java/com/despegar/sparkjava/test/TestControllerTest.java
+++ b/src/test/java/com/despegar/sparkjava/test/TestControllerTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import com.despegar.http.client.GetMethod;
 import com.despegar.http.client.HttpResponse;
+import com.despegar.sparkjava.test.SparkServer.HeadMethod;
 
 import spark.servlet.SparkApplication;
 
@@ -43,6 +44,17 @@ public class TestControllerTest {
 		HttpResponse httpResponse = testServer.execute(get);
 		assertEquals(200, httpResponse.code());
 		assertEquals("This works!", new String(httpResponse.body()));
+		assertNotNull(testServer.getApplication());
+	}
+	
+	@Test
+	public void testHead() throws Exception {
+		HeadMethod head = testServer.head("/test", false);
+		head.addHeader("Test-Header", "test");
+		HttpResponse httpResponse = testServer.execute(head);
+		assertEquals(200, httpResponse.code());
+		assertEquals("", new String(httpResponse.body()));
+		assertEquals("bar", httpResponse.headers().get("foo").get(0));
 		assertNotNull(testServer.getApplication());
 	}
 	


### PR DESCRIPTION
Fix for #7.

I implemented `HeadMethod` as inner class in `SparkServer` because I could not find source code repo of `com.despegar:http-java-native-client`.