### PR TITLE
Adding default value to follow redirect

### DIFF
--- a/src/main/java/com/despegar/sparkjava/test/SparkServer.java
+++ b/src/main/java/com/despegar/sparkjava/test/SparkServer.java
@@ -35,7 +35,9 @@ public class SparkServer<T extends SparkApplication> extends ExternalResource {
     
     private String protocolHostPort;
     
-    private HttpClient httpClient;
+	private HttpClient httpClient;
+	
+	private boolean defaultFollowRedirect;
     
     /**
      * Constructor. It will use default Spark port ({@link Service#SPARK_DEFAULT_PORT}
@@ -51,10 +53,21 @@ public class SparkServer<T extends SparkApplication> extends ExternalResource {
      * @param port port where to run server
      */
     public SparkServer(Class<T> sparkApplicationClass, int port) {
+    	this(sparkApplicationClass, port, true);
+	}
+    
+    /**
+     * Constructor
+     * @param sparkApplicationClass {@link SparkApplication} to use
+     * @param port port where to run server
+	 * @param defaultFollowRedirect default value for followRedirect, used when not provided
+     */
+    public SparkServer(Class<T> sparkApplicationClass, int port, boolean defaultFollowRedirect) {
     	this.sparkApplicationClass = sparkApplicationClass;
     	this.port = port;
     	this.protocolHostPort = "http://localhost:" + port;
-    	this.httpClient = new HttpClient(1);
+		this.httpClient = new HttpClient(1);
+		this.defaultFollowRedirect = defaultFollowRedirect;
     }
 
     public T getApplication() {
@@ -76,31 +89,59 @@ public class SparkServer<T extends SparkApplication> extends ExternalResource {
     	this.sparkApplication.init();
     	Spark.awaitInitialization();
     }
-    
+	
+	public GetMethod get(String path) {
+		return get(path, defaultFollowRedirect);
+	}
+
     public GetMethod get(String path, boolean followRedirect) {
 		return new GetMethod(this.protocolHostPort + path, followRedirect);
 	}
-	
+
+	public PostMethod post(String path, String body) {
+		return post(path, body, defaultFollowRedirect);
+	}
+
 	public PostMethod post(String path, String body, boolean followRedirect) {
 		return new PostMethod(this.protocolHostPort + path, body, followRedirect);
 	}
-	
+
+	public PutMethod put(String path, String body) {
+		return put(path, body, defaultFollowRedirect);
+	}
+
 	public PutMethod put(String path, String body, boolean followRedirect) {
 		return new PutMethod(this.protocolHostPort + path, body, followRedirect);
 	}
 	
+	public PatchMethod patch(String path, String body) {
+		return patch(path, body, defaultFollowRedirect);
+	}
+
 	public PatchMethod patch(String path, String body, boolean followRedirect) {
 		return new PatchMethod(this.protocolHostPort + path, body, followRedirect);
 	}
 	
+	public DeleteMethod delete(String path) {
+		return delete(path, defaultFollowRedirect);
+	}
+
 	public DeleteMethod delete(String path, boolean followRedirect) {
 		return new DeleteMethod(this.protocolHostPort + path, followRedirect);
 	}
 	
+	public OptionsMethod options(String path) {
+		return options(path, defaultFollowRedirect);
+	}
+
 	public OptionsMethod options(String path, boolean followRedirect) {
 		return new OptionsMethod(this.protocolHostPort + path, followRedirect);
 	}
 	
+	public HeadMethod head(String path) {
+		return head(path, defaultFollowRedirect);
+	}
+
 	public HeadMethod head(String path, boolean followRedirect) {
 		return new HeadMethod(this.protocolHostPort + path, followRedirect);
 	}

--- a/src/test/java/com/despegar/sparkjava/test/TestController.java
+++ b/src/test/java/com/despegar/sparkjava/test/TestController.java
@@ -1,6 +1,6 @@
 package com.despegar.sparkjava.test;
 
-import static spark.Spark.get;
+import static spark.Spark.*;
 
 import spark.Request;
 import spark.Response;
@@ -14,6 +14,7 @@ public class TestController {
 
 	public TestController() {
 		get("/test", (request, response) ->  this.testMethod(request, response));
+		redirect.get("/redirect", "/test");
 	}
 	
 	public String testMethod(Request request, Response response) {

--- a/src/test/java/com/despegar/sparkjava/test/TestControllerTest.java
+++ b/src/test/java/com/despegar/sparkjava/test/TestControllerTest.java
@@ -45,6 +45,17 @@ public class TestControllerTest {
 		assertEquals("This works!", new String(httpResponse.body()));
 		assertNotNull(testServer.getApplication());
 	}
-	
+
+	@Test
+	public void testDefaultFollowRedirect() throws Exception {
+		SparkServer<TestControllerTest.TestContollerTestSparkApplication> serverDoFollow = new SparkServer<>(TestControllerTest.TestContollerTestSparkApplication.class, 4567, true);
+		HttpResponse httpResponse = testServer.execute(serverDoFollow.get("/redirect"));
+		assertEquals(200, httpResponse.code());
+		assertEquals("This works!", new String(httpResponse.body()));
+
+		SparkServer<TestControllerTest.TestContollerTestSparkApplication> serverDontFollow = new SparkServer<>(TestControllerTest.TestContollerTestSparkApplication.class, 4567, false);
+		httpResponse = testServer.execute(serverDontFollow.get("/redirect"));
+		assertEquals(302, httpResponse.code());
+	}
 	
 }


### PR DESCRIPTION
Adding default value to follow redirect, in order to make API simpler to use in general.

It can be set on the constructor, and it is true by default.

Every method gets an overload that doesn't require the `followRedirect` flag and uses the default value provided.

I think in most use cases all the requests in the tests will use the same value for this, so this change make the API a bit simpler to use in some cases.

Please let me know what you think!

I've also added a test to verify this case.